### PR TITLE
fix(layer-injector): Allow user-set zDepth values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "better-popover",
-  "version": "1.9.5",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "dependencies": {
     "@typeless/jss": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-popover",
-  "version": "1.9.5",
+  "version": "1.10.0",
   "main": "./build/index.es.js",
   "description": "Material Design-inspired popover React components with support for user-specified options to enable further enhancements/customizations",
   "license": "GPL-3.0",

--- a/src/Popover/LayerInjector.jsx
+++ b/src/Popover/LayerInjector.jsx
@@ -12,29 +12,20 @@ export default class LayerInjector extends Component {
     handleClickAway: PropTypes.func.isRequired,
     isOpen: PropTypes.bool.isRequired,
     render: PropTypes.func.isRequired,
+    zDepth: PropTypes.number,
   };
 
   static defaultProps = {
     handleClickAway() {},
     isOpen: false,
     render() {},
+    zDepth: 2000,
   };
 
-  constructor(props) {
-    super(props);
-  }
+  componentDidMount() { this.renderLayer(); }
+  componentDidUpdate() { this.renderLayer(); }
 
-  componentDidMount() {
-    this.renderLayer();
-  }
-
-  componentDidUpdate() {
-    this.renderLayer();
-  }
-
-  getPortal() {
-    return this.layer;
-  }
+  getPortal() { return this.layer; }
 
   onClickAway = (evt) => {
     if (!recursiveDescent(this.layer, evt.target)) {
@@ -60,10 +51,7 @@ export default class LayerInjector extends Component {
    *  entirely different part of the page.
    */
   renderLayer() {
-    const {
-      isOpen,
-      render,
-    } = this.props;
+    const { isOpen, render, zDepth } = this.props;
 
     if (isOpen) {
       if (!this.layer) {
@@ -77,7 +65,7 @@ export default class LayerInjector extends Component {
         this.layer.style.bottom = 0;
         this.layer.style.left = 0;
         this.layer.style.right = 0;
-        this.layer.style.zIndex = 2000;
+        this.layer.style.zIndex = (zDepth || 2000);
       }
 
       const layerElement = render();

--- a/src/Popover/PopoverPure.jsx
+++ b/src/Popover/PopoverPure.jsx
@@ -25,6 +25,7 @@ export default class PopoverPure extends Component {
       horizontal: PropTypes.string,
       vertical: PropTypes.string,
     }),
+    zDepth: PropTypes.number,
   };
 
   static defaultProps = {
@@ -44,13 +45,14 @@ export default class PopoverPure extends Component {
       horizontal: 'left',
       vertical: 'top',
     },
+    zDepth: 2000,
   };
 
   constructor(props) {
     super(props);
 
     this.requestClose = ::this.requestClose;
-    this.handleResize = throttle(this.positionPopover, 100);
+    // this.handleResize = throttle(this.positionPopover, 100);
     this.scrollHandler = throttle(this.positionPopover.bind(this, true), 50);
   }
 
@@ -81,9 +83,9 @@ export default class PopoverPure extends Component {
     return (
       <div
         style={{
-          ...style,
           opacity: open ? 1 : 0,
-          transform: open ? 'scaleY(1)' : 'scaleY(0)',
+          transform: `scaleY(${open ? 1 : 0})`,
+          ...style, // Order last to ensure properties override
         }}
         className={classNames.popoverContainer}
       >
@@ -198,7 +200,7 @@ export default class PopoverPure extends Component {
   }
 
   render() {
-    const { isOpen } = this.props;
+    const { isOpen, zDepth } = this.props;
 
     return (
       <div>
@@ -208,10 +210,11 @@ export default class PopoverPure extends Component {
           onScroll={this.scrollHandler}
         />
         <LayerInjector
-          isOpen={isOpen}
-          render={this.renderLayer}
           handleClickAway={this.requestClose}
+          isOpen={isOpen}
           ref={(portal) => { this.portal = portal; }}
+          render={this.renderLayer}
+          zDepth={zDepth || 2000}
         />
       </div>
     );


### PR DESCRIPTION
- Disable event cancellation method calls for the `handleResize` function
+ Allow dynamic setting of the modal's `zIndex` vis-á-vis the user-specified `zDepth` prop 